### PR TITLE
add `export-stat`

### DIFF
--- a/export-stat/Main.hs
+++ b/export-stat/Main.hs
@@ -1,0 +1,83 @@
+import Optics (view)
+import System.Exit (die)
+import Data.Aeson qualified as Aeson
+import System.Environment (getArgs, getProgName)
+import System.FilePath (takeBaseName)
+import GHC.Generics qualified as GHC
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Short qualified as SBS
+import ScriptExport.ScriptInfo (RawScriptExport, ScriptExport)
+import Data.Map (Map, fromList, toList)
+import Data.Text (Text)
+import Control.Applicative ((<|>))
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Codec.Serialise (serialise)
+import Plutarch.Evaluate (evalScript)
+import PlutusLedgerApi.V2 (
+  ExBudget (ExBudget),
+  ExCPU (..),
+  ExMemory (..),
+  Script,
+ )
+import Ply (TypedScriptEnvelope(tsScript))
+
+data FileFormats
+  = Raw RawScriptExport
+  | Export (ScriptExport ())
+  | MultipleExport (Map Text (ScriptExport ()))
+  deriving stock Show
+
+data ScriptStats
+  = ScriptStats
+  { size :: Int
+  , cpuBudget :: ExCPU
+  , memBudget :: ExMemory
+  }
+  deriving stock (Show, GHC.Generic)
+  deriving anyclass (Aeson.ToJSON)
+
+help :: IO a
+help = do
+  pname <- getProgName
+  die $ "Usage: " <> pname <> " [export/raw export file]"
+
+decodeExport :: FilePath -> IO (Either String FileFormats)
+decodeExport filename = do
+  content <- BS.readFile filename <|> help
+
+  return $
+    Raw <$> Aeson.eitherDecodeStrict content
+    <|> Export <$> Aeson.eitherDecodeStrict content
+    <|> MultipleExport <$> Aeson.eitherDecodeStrict content
+
+makeStats :: FileFormats -> Map Text ScriptStats
+makeStats =
+  \case
+    Raw e -> (go . tsScript) <$> view #rawScripts e
+    Export e -> go <$> view #scripts e
+    MultipleExport e ->
+      fromList $
+        foldMap (\(k, x) -> (\(k', x') -> (k <> "-" <> k', go x')) <$>
+                  toList (view #scripts x)) $ toList e
+  where
+    go :: Script -> ScriptStats
+    go script =
+      let (_res, ExBudget cpu mem, _traces) = evalScript script
+          size = SBS.length . SBS.toShort . LBS.toStrict . serialise $ script
+      in ScriptStats size cpu mem
+
+main :: IO ()
+main = do
+  exportFile <-
+    getArgs >>= \case
+      (x: _) -> return x
+      _ -> help
+
+  exportContent' <- decodeExport exportFile
+
+  case exportContent' of
+    Left e -> die $ "Failed to parse: " <> e
+    Right exportContent ->
+      LBS.writeFile (takeBaseName exportFile <> "-stats.json") . encodePretty $
+        makeStats exportContent

--- a/liqwid-script-export.cabal
+++ b/liqwid-script-export.cabal
@@ -93,6 +93,7 @@ common deps
     , wai
     , wai-cors
     , warp
+    , filepath
 
   mixins:
 
@@ -110,6 +111,12 @@ library
   other-modules:
     Codec.Serialise.Orphans
     Data.Cache.Cached
+
+executable export-stat
+  import:         lang, deps
+  hs-source-dirs: export-stat
+  main-is:         Main.hs
+  build-depends: liqwid-script-export
 
 executable example
   import:         lang, deps


### PR DESCRIPTION
It supports raw and regular exports as well as liqwid exports -- on that has multiple `ScriptExport`s in a map. 

Let me know if we need any other stat value. 

~~Also, I'm not sure if `size` is in `KB`. It is length of serialized script.~~ It is in `B` as oppose to `KB`. It can be changed if necessary. (Thanks Tommy)

Note, I don't think this can replace other benches we have, since it only provides stats for (raw)script exports. We would still need benchmarks for specific cases and stuff. 

example: 
```json
{
    "agora:authorityTokenPolicy": {
        "cpuBudget": 1426100,
        "memBudget": 6300,
        "size": 558
    },
    "agora:governorPolicy": {
        "cpuBudget": 1403100,
        "memBudget": 6200,
        "size": 1228
    },
    "agora:governorValidator": {
        "cpuBudget": 4968100,
        "memBudget": 21700,
        "size": 6840
    },
...
}
```

(I put `SomethingSomething` market intentionally)
```json
{
    "Ada-batchFinal": {
        "cpuBudget": 4416100,
        "memBudget": 19300,
        "size": 4090
    },
    "Ada-batchToken": {
        "cpuBudget": 1265100,
        "memBudget": 5600,
        "size": 477
    },
 ...
    "SomethingSomething-batchFinal": {
        "cpuBudget": 4416100,
        "memBudget": 19300,
        "size": 4090
    },
    "SomethingSomething-batchToken": {
        "cpuBudget": 1265100,
        "memBudget": 5600,
        "size": 477
    },
...
}
```