### PR TITLE
Use subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.2.0 -- 2022-11-29
+
+### Modified
+
+- Now supports subcommand system
+- File export reqires user to select specific builder to use.
+- Add a subcommand to list all builders
+- Dropped Git revesion support that was broken
+
 ## 2.1.0 -- 2022-11-02
 
 ### Added

--- a/liqwid-script-export.cabal
+++ b/liqwid-script-export.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-script-export
-version:            2.1.0
+version:            2.2.0
 extra-source-files: CHANGELOG.md
 author:             Emily Martins <emi@haskell.fyi>
 license:            Apache-2.0
@@ -68,7 +68,6 @@ common deps
     , data-default-class
     , filepath
     , generics-sop
-    , gitrev
     , hashable
     , http-types
     , liqwid-plutarch-extra

--- a/src/ScriptExport/API.hs
+++ b/src/ScriptExport/API.hs
@@ -61,10 +61,10 @@ type API =
 
 {- | Run a Warp server that exposes a script generation endpoint.
 
-     @since 2.0.0
+     @since 2.2.0
 -}
-runServer :: MonadIO m => Text -> Builders -> ServerOptions -> m ()
-runServer revision builders options = do
+runServer :: MonadIO m => Builders -> ServerOptions -> m ()
+runServer builders options = do
   let logger req status _maybeFileSize =
         putStrLn . renderString . layoutPretty defaultLayoutOptions $
           hsep
@@ -88,10 +88,7 @@ runServer revision builders options = do
       corsMiddleware = cors . const $ Just corsPolicy
 
       serverInfo =
-        ExporterInfo
-          { revision = revision
-          , exposedBuilders = Builders.toList builders
-          }
+        ExporterInfo $ Builders.toList builders
 
   -- Scripts stay cached for the amount of time specified by the `cacheLifetime` option.
   query <- cachedForM (Just $ TimeSpec (view #cacheLifetime options) 0) (`runQuery` builders)

--- a/src/ScriptExport/Export.hs
+++ b/src/ScriptExport/Export.hs
@@ -1,29 +1,25 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module ScriptExport.Export (
   exportMain,
 ) where
 
+import Data.Text (intercalate, unpack)
 import ScriptExport.API (runServer)
 import ScriptExport.File (runFile)
-import ScriptExport.Options (Options (FileOption, ServerOption), parseOptions)
-import ScriptExport.Types (Builders)
-
-import Data.Text (Text)
-import Development.GitRev (gitBranch, gitHash)
+import ScriptExport.Options (
+  Options (FileOption, ListBuilders, ServerOption),
+  parseOptions,
+ )
+import ScriptExport.Types (Builders, toList)
 
 {- | Program entry point. It provides both file and servant api.
 
- @since 2.0.0
+ @since 2.2.0
 -}
 exportMain :: Builders -> IO ()
 exportMain builders = do
   opts <- parseOptions
   case opts of
-    ServerOption so -> runServer revision builders so
-    FileOption fo -> runFile revision builders fo
-  where
-    -- This encodes the git revision of the server. It's useful for the caller
-    -- to be able to ensure they are compatible with it.
-    revision :: Text
-    revision = $(gitBranch) <> "@" <> $(gitHash)
+    ServerOption so -> runServer builders so
+    FileOption fo -> runFile builders fo
+    ListBuilders ->
+      putStrLn $ unpack $ intercalate "\n" $ toList builders

--- a/src/ScriptExport/File.hs
+++ b/src/ScriptExport/File.hs
@@ -6,29 +6,33 @@ import ScriptExport.Options (FileOptions)
 import ScriptExport.Types (Builders, getBuilders, handleServe)
 
 import Control.Applicative (optional)
-import Control.Monad (forM_)
 import Control.Monad.Except (runExcept)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
-import Data.Map (toList)
-import Data.Text (Text, unpack)
+import Data.Map ((!?))
+import Data.Text (unpack)
 import Optics (view)
+import System.Exit (die)
 
 {- | Exports 'Builders' into file.
 
- @since 2.0.0
+ @since 2.2.0
 -}
-runFile :: Text -> Builders -> FileOptions -> IO ()
-runFile _revision builders options = do
+runFile :: Builders -> FileOptions -> IO ()
+runFile builders options = do
   paramFile <- optional $ BS.readFile (view #param options)
   let param = paramFile >>= Aeson.decodeStrict'
+      builder = view #builder options
 
-  forM_ (toList $ getBuilders builders) $ \(n, s) -> do
-    case runExcept $ handleServe param s of
-      Left err -> putStrLn . unpack $ "Skipped " <> n <> ": " <> err
-      Right x -> do
-        LBS.writeFile (view #out options <> "/" <> unpack n <> ".json") $
-          encodePretty x
-        putStrLn . unpack $ "Wrote " <> n
+  case getBuilders builders !? builder of
+    Just b ->
+      case runExcept $ handleServe param b of
+        Left err -> die . unpack $ "Script compilation failed:\n\t" <> err
+        Right x -> do
+          LBS.writeFile
+            (view #out options <> "/" <> unpack builder <> ".json")
+            (encodePretty x)
+          putStrLn . unpack $ "Wrote " <> builder
+    Nothing -> die . unpack $ builder <> " does not exist"

--- a/src/ScriptExport/Options.hs
+++ b/src/ScriptExport/Options.hs
@@ -159,7 +159,7 @@ parseOptions = Opt.execParser p
     opt =
       Opt.subparser . foldMap mkSubcommand $
         [ (FileOption <$> fileOpt, "file", "Complie scripts using file IO")
-        , (ServerOption <$> serverOpt, "server", "Start script server")
+        , (ServerOption <$> serverOpt, "serve", "Start script server")
         , (pure ListBuilders, "list", "List out all builders")
         ]
     mkSubcommand (p, n, d) =


### PR DESCRIPTION
```
Usage: example COMMAND

  Script exporting server for plutus/plutarch scripts.

Available options:
  -h,--help                Show this help text

Available commands:
  file                     Complie scripts using file IO
  server                   Start script server
  list                     List out all builders
```
```
Usage: example file [-o|--out OUT] [-p|--param PARAM] (-b|--builder BUILDER)

  Complie scripts using file IO

Available options:
  -o,--out OUT             Where to write files to.
  -p,--param PARAM         Parameters to apply
  -b,--builder BUILDER     Bulider to use
  -h,--help                Show this help text
```